### PR TITLE
Review Prettier config overrides

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,4 @@
 {
-  "printWidth": 80,
-  "semi": true,
-  "singleQuote": true,
-  "trailingComma": "es5"
+  "semi": false,
+  "singleQuote": true
 }

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
-import { createRoot } from 'react-dom/client';
-import { Policy, PunditProvider, When } from '../src/index';
+import * as React from 'react'
+import { createRoot } from 'react-dom/client'
+import { Policy, PunditProvider, When } from '../src/index'
 
-const user = {};
-const record = {};
-const policy = new Policy(user, record);
-policy.add('view', () => true);
-policy.add('edit', () => false);
+const user = {}
+const record = {}
+const policy = new Policy(user, record)
+policy.add('view', () => true)
+policy.add('edit', () => false)
 
 function App(): React.ReactElement {
   return (
@@ -19,11 +19,11 @@ function App(): React.ReactElement {
         <span>edit</span>
       </When>
     </PunditProvider>
-  );
+  )
 }
 
-const container = document.getElementById('root');
+const container = document.getElementById('root')
 if (container !== null) {
-  const root = createRoot(container);
-  root.render(<App />);
+  const root = createRoot(container)
+  root.render(<App />)
 }

--- a/example/vite.config.js
+++ b/example/vite.config.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-});
+})

--- a/readme.md
+++ b/readme.md
@@ -45,15 +45,15 @@ A policy accepts a user, often the current user of your session, and the
 resource you wish to authorize against.
 
 ```javascript
-import { Policy } from 'pundit';
+import { Policy } from 'pundit'
 
-const postPolicy = new Policy(user, postRecord);
+const postPolicy = new Policy(user, postRecord)
 
-postPolicy.add('edit', (user, record) => user.id === record.userId);
-postPolicy.add('destroy', (user) => user.isAdmin());
+postPolicy.add('edit', (user, record) => user.id === record.userId)
+postPolicy.add('destroy', (user) => user.isAdmin())
 
-postPolicy.can('edit');
-postPolicy.can('destroy');
+postPolicy.can('edit')
+postPolicy.can('destroy')
 ```
 
 ### Using with React

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import Policy from './policy';
-import When from './react/when';
+import Policy from './policy'
+import When from './react/when'
 
-export { Policy };
-export { PunditProvider, usePundit } from './react/pundit-provider';
-export { When };
+export { Policy }
+export { PunditProvider, usePundit } from './react/pundit-provider'
+export { When }

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,32 +1,32 @@
-type ActionFunction = (user: unknown, record: unknown) => boolean;
+type ActionFunction = (user: unknown, record: unknown) => boolean
 
 export default class Policy {
-  user: unknown;
+  user: unknown
 
-  record: unknown;
+  record: unknown
 
-  actions: Map<string, ActionFunction>;
+  actions: Map<string, ActionFunction>
 
   constructor(user: unknown, record: unknown) {
-    this.user = user;
-    this.record = record;
-    this.actions = new Map();
+    this.user = user
+    this.record = record
+    this.actions = new Map()
   }
 
   can(actionName: string): boolean {
-    const actionFn = this.actions.get(actionName);
-    return actionFn !== undefined ? actionFn(this.user, this.record) : false;
+    const actionFn = this.actions.get(actionName)
+    return actionFn !== undefined ? actionFn(this.user, this.record) : false
   }
 
   add(actionName: string, actionFn: ActionFunction): void {
-    this.actions.set(actionName, actionFn);
+    this.actions.set(actionName, actionFn)
   }
 
   copy(user: unknown, record: unknown): Policy {
-    const newPolicy = new Policy(user || this.user, record || this.record);
+    const newPolicy = new Policy(user || this.user, record || this.record)
     this.actions.forEach((actionFunction, actionName) => {
-      newPolicy.add(actionName, actionFunction);
-    });
-    return newPolicy;
+      newPolicy.add(actionName, actionFunction)
+    })
+    return newPolicy
   }
 }

--- a/src/react/pundit-provider.tsx
+++ b/src/react/pundit-provider.tsx
@@ -1,24 +1,24 @@
-import React, { JSX, ReactElement, useMemo } from 'react';
-import Policy from '../policy';
+import React, { JSX, ReactElement, useMemo } from 'react'
+import Policy from '../policy'
 
-const PunditContext = React.createContext({ policy: new Policy(null, null) });
+const PunditContext = React.createContext({ policy: new Policy(null, null) })
 
 interface PunditContextProps {
-  children: JSX.Element | JSX.Element[] | null;
-  policy: Policy;
+  children: JSX.Element | JSX.Element[] | null
+  policy: Policy
 }
 
 export const usePundit = (): { policy: Policy } => {
-  const value = React.useContext(PunditContext);
-  return value;
-};
+  const value = React.useContext(PunditContext)
+  return value
+}
 
 export function PunditProvider({
   policy,
   children,
 }: PunditContextProps): ReactElement {
-  const value = useMemo(() => ({ policy }), [policy]);
+  const value = useMemo(() => ({ policy }), [policy])
   return (
     <PunditContext.Provider value={value}>{children}</PunditContext.Provider>
-  );
+  )
 }

--- a/src/react/when.tsx
+++ b/src/react/when.tsx
@@ -1,12 +1,12 @@
-import Policy from '../policy';
-import { usePundit } from './pundit-provider';
+import Policy from '../policy'
+import { usePundit } from './pundit-provider'
 
 interface WhenProps {
-  children: JSX.Element | null;
-  can: string;
-  policy?: Policy;
-  user?: unknown;
-  record?: unknown;
+  children: JSX.Element | null
+  can: string
+  policy?: Policy
+  user?: unknown
+  record?: unknown
 }
 
 export default function When({
@@ -16,16 +16,16 @@ export default function When({
   user,
   record,
 }: WhenProps): JSX.Element | null {
-  const { policy: hookPolicy } = usePundit();
-  const paramPolicy = policy?.copy(user, record);
+  const { policy: hookPolicy } = usePundit()
+  const paramPolicy = policy?.copy(user, record)
   const canPerformAction = paramPolicy
     ? paramPolicy.can(can)
-    : hookPolicy.can(can);
-  return canPerformAction ? children : null;
+    : hookPolicy.can(can)
+  return canPerformAction ? children : null
 }
 
 When.defaultProps = {
   policy: undefined,
   user: undefined,
   record: undefined,
-};
+}

--- a/test-setup.js
+++ b/test-setup.js
@@ -1,1 +1,1 @@
-import 'vitest-dom/extend-expect';
+import 'vitest-dom/extend-expect'

--- a/test/policy.test.tsx
+++ b/test/policy.test.tsx
@@ -1,76 +1,76 @@
-import Policy from '../src/policy';
+import Policy from '../src/policy'
 
 describe('can function', () => {
-  const policy = new Policy(null, null);
+  const policy = new Policy(null, null)
 
   it('returns true if the action is authorised', () => {
-    const actionName = 'view';
-    policy.add(actionName, () => true);
-    expect(policy.can(actionName)).toBe(true);
-  });
+    const actionName = 'view'
+    policy.add(actionName, () => true)
+    expect(policy.can(actionName)).toBe(true)
+  })
 
   it('returns false if the action is not authorised', () => {
-    const actionName = 'edit';
-    policy.add(actionName, () => false);
-    expect(policy.can(actionName)).toBe(false);
-  });
+    const actionName = 'edit'
+    policy.add(actionName, () => false)
+    expect(policy.can(actionName)).toBe(false)
+  })
 
   it('returns false if the action does not exist', () => {
-    const actionName = 'missingAction';
-    expect(policy.can(actionName)).toBe(false);
-  });
-});
+    const actionName = 'missingAction'
+    expect(policy.can(actionName)).toBe(false)
+  })
+})
 
 describe('add function', () => {
-  const policy = new Policy(null, null);
+  const policy = new Policy(null, null)
 
   it('adds an action to an instance of the Policy class', () => {
-    const actionName = 'view';
-    const actionFunction = (): boolean => true;
-    policy.add(actionName, actionFunction);
-    expect(policy.actions.get(actionName)).toEqual(actionFunction);
-  });
+    const actionName = 'view'
+    const actionFunction = (): boolean => true
+    policy.add(actionName, actionFunction)
+    expect(policy.actions.get(actionName)).toEqual(actionFunction)
+  })
 
   it('allows the action function to be replaced', () => {
-    const actionName = 'edit';
-    const actionFunction = (): boolean => true;
-    policy.add(actionName, actionFunction);
-    const replacementFunction = (): boolean => false;
-    policy.add(actionName, replacementFunction);
-    expect(policy.actions.get(actionName)).toEqual(replacementFunction);
-  });
-});
+    const actionName = 'edit'
+    const actionFunction = (): boolean => true
+    policy.add(actionName, actionFunction)
+    const replacementFunction = (): boolean => false
+    policy.add(actionName, replacementFunction)
+    expect(policy.actions.get(actionName)).toEqual(replacementFunction)
+  })
+})
 
 describe('copy function', () => {
   it('copies the user and record params when these are specified', () => {
-    const originalPolicy = new Policy(undefined, undefined);
-    const paramUser = { id: 1 };
-    const paramRecord = { id: 10 };
-    const copiedPolicy = originalPolicy.copy(paramUser, paramRecord);
-    expect(copiedPolicy.user).toEqual(paramUser);
-    expect(copiedPolicy.record).toEqual(paramRecord);
-  });
+    const originalPolicy = new Policy(undefined, undefined)
+    const paramUser = { id: 1 }
+    const paramRecord = { id: 10 }
+    const copiedPolicy = originalPolicy.copy(paramUser, paramRecord)
+    expect(copiedPolicy.user).toEqual(paramUser)
+    expect(copiedPolicy.record).toEqual(paramRecord)
+  })
 
   it('copies the user and record of the original policy', () => {
-    const originalPolicy = new Policy({ id: 1 }, { id: 10 });
-    const copiedPolicy = originalPolicy.copy(undefined, undefined);
-    expect(copiedPolicy.user).toEqual(originalPolicy.user);
-    expect(copiedPolicy.record).toEqual(originalPolicy.record);
-  });
+    const originalPolicy = new Policy({ id: 1 }, { id: 10 })
+    const copiedPolicy = originalPolicy.copy(undefined, undefined)
+    expect(copiedPolicy.user).toEqual(originalPolicy.user)
+    expect(copiedPolicy.record).toEqual(originalPolicy.record)
+  })
 
   it('prioritises user/record params over the original policy fields', () => {
-    const originalPolicy = new Policy({ id: 1 }, { id: 10 });
-    const copiedPolicy = originalPolicy.copy({ id: 2 }, { id: 11 });
-    expect(copiedPolicy.user).not.toEqual(originalPolicy.user);
-    expect(copiedPolicy.record).not.toEqual(originalPolicy.record);
-  });
+    const originalPolicy = new Policy({ id: 1 }, { id: 10 })
+    const copiedPolicy = originalPolicy.copy({ id: 2 }, { id: 11 })
+    expect(copiedPolicy.user).not.toEqual(originalPolicy.user)
+    expect(copiedPolicy.record).not.toEqual(originalPolicy.record)
+  })
 
   it('copies an action of the original policy', () => {
-    const originalPolicy = new Policy(undefined, undefined);
-    const actionName = 'view';
-    const actionFunction = (): boolean => true;
-    originalPolicy.add(actionName, actionFunction);
-    const copiedPolicy = originalPolicy.copy(undefined, undefined);
-    expect(copiedPolicy.actions.get(actionName)).toEqual(actionFunction);
-  });
-});
+    const originalPolicy = new Policy(undefined, undefined)
+    const actionName = 'view'
+    const actionFunction = (): boolean => true
+    originalPolicy.add(actionName, actionFunction)
+    const copiedPolicy = originalPolicy.copy(undefined, undefined)
+    expect(copiedPolicy.actions.get(actionName)).toEqual(actionFunction)
+  })
+})

--- a/test/react/pundit-provider.test.tsx
+++ b/test/react/pundit-provider.test.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import Policy from '../../src/policy';
-import { PunditProvider } from '../../src/react/pundit-provider';
-import When from '../../src/react/when';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Policy from '../../src/policy'
+import { PunditProvider } from '../../src/react/pundit-provider'
+import When from '../../src/react/when'
 
 describe('<PunditProvider />', () => {
-  const user = {};
-  const record = {};
-  const policy = new Policy(user, record);
-  policy.add('view', () => true);
-  policy.add('edit', () => false);
+  const user = {}
+  const record = {}
+  const policy = new Policy(user, record)
+  policy.add('view', () => true)
+  policy.add('edit', () => false)
 
   it('displays <When /> child when action is permitted', () => {
     render(
@@ -18,9 +18,9 @@ describe('<PunditProvider />', () => {
           <button type="button">View</button>
         </When>
       </PunditProvider>
-    );
-    expect(screen.queryByText('View')).toBeInTheDocument();
-  });
+    )
+    expect(screen.queryByText('View')).toBeInTheDocument()
+  })
 
   it('does not display <When /> child when action is forbidden', () => {
     render(
@@ -29,9 +29,9 @@ describe('<PunditProvider />', () => {
           <button type="button">Edit</button>
         </When>
       </PunditProvider>
-    );
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-  });
+    )
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
 
   it('authorises multiple <When /> children from a single provider', () => {
     render(
@@ -43,10 +43,10 @@ describe('<PunditProvider />', () => {
           <button type="button">Edit</button>
         </When>
       </PunditProvider>
-    );
-    expect(screen.queryByText('View')).toBeInTheDocument();
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-  });
+    )
+    expect(screen.queryByText('View')).toBeInTheDocument()
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
 
   it('authorises nested <When /> child elements', () => {
     render(
@@ -60,10 +60,10 @@ describe('<PunditProvider />', () => {
           </>
         </When>
       </PunditProvider>
-    );
-    expect(screen.queryByText('View')).toBeInTheDocument();
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-  });
+    )
+    expect(screen.queryByText('View')).toBeInTheDocument()
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+  })
 
   it('does not authorise <When /> children outside of a provider', () => {
     render(
@@ -75,7 +75,7 @@ describe('<PunditProvider />', () => {
           <button type="button">View</button>
         </When>
       </>
-    );
-    expect(screen.queryByText('View')).not.toBeInTheDocument();
-  });
-});
+    )
+    expect(screen.queryByText('View')).not.toBeInTheDocument()
+  })
+})

--- a/test/react/when.test.tsx
+++ b/test/react/when.test.tsx
@@ -1,129 +1,129 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import Policy from '../../src/policy';
-import When from '../../src/react/when';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Policy from '../../src/policy'
+import When from '../../src/react/when'
 
 describe('<When />', () => {
   describe('policy parameter', () => {
-    const user = {};
-    const record = {};
-    const policy = new Policy(user, record);
-    policy.add('view', () => true);
-    policy.add('edit', () => false);
+    const user = {}
+    const record = {}
+    const policy = new Policy(user, record)
+    policy.add('view', () => true)
+    policy.add('edit', () => false)
 
     it('displays <When /> child when action is permitted using "policy" param', () => {
       render(
         <When can="view" policy={policy}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
 
     it('does not display <When /> child when action is forbidden using "policy" param', () => {
       render(
         <When can="edit" policy={policy}>
           <button type="button">Edit</button>
         </When>
-      );
-      expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
 
     it('does not display <When /> child when "policy" param is missing', () => {
       render(
         <When can="view">
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).not.toBeInTheDocument();
-    });
-  });
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
+  })
 
   describe('user parameter', () => {
-    const user = {};
-    const record = {};
-    const policy = new Policy(null, record);
-    policy.add('view', () => true);
-    policy.add('edit', () => false);
+    const user = {}
+    const record = {}
+    const policy = new Policy(null, record)
+    policy.add('view', () => true)
+    policy.add('edit', () => false)
 
     it('displays <When /> child when action is permitted using "user" param', () => {
       render(
         <When can="view" policy={policy} user={user}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
 
     it('does not display <When /> child when action is forbidden using "user" param', () => {
       render(
         <When can="edit" policy={policy} user={user}>
           <button type="button">Edit</button>
         </When>
-      );
-      expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
 
     it('does not display <When /> child when the "policy" param has a null user and the "user" param is missing', () => {
       render(
         <When can="view" policy={new Policy(null, record)}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).not.toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
 
     it('does not display <When /> child when "user" param is specified but the "policy" param is missing', () => {
       render(
         <When can="view" user={user}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).not.toBeInTheDocument();
-    });
-  });
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
+  })
 
   describe('record parameter', () => {
-    const user = {};
-    const record = {};
-    const policy = new Policy(user, null);
-    policy.add('view', () => true);
-    policy.add('edit', () => false);
+    const user = {}
+    const record = {}
+    const policy = new Policy(user, null)
+    policy.add('view', () => true)
+    policy.add('edit', () => false)
 
     it('displays <When /> child when action is permitted using "record" param', () => {
       render(
         <When can="view" policy={policy} record={record}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
 
     it('does not display <When /> child when action is forbidden using "record" param', () => {
       render(
         <When can="edit" policy={policy} record={record}>
           <button type="button">Edit</button>
         </When>
-      );
-      expect(screen.queryByText('Edit')).not.toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
 
     it('does not display <When /> child when the "policy" param has a null record and the "record" param is missing', () => {
       render(
         <When can="view" policy={new Policy(user, null)}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).not.toBeInTheDocument();
-    });
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
 
     it('does not display <When /> child when the "record" param is specified but the "policy" param is missing', () => {
       render(
         <When can="view" record={record}>
           <button type="button">View</button>
         </When>
-      );
-      expect(screen.queryByText('View')).not.toBeInTheDocument();
-    });
-  });
-});
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
-import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -25,4 +25,4 @@ export default defineConfig({
     // since parsing CSS is slow
     css: false,
   },
-});
+})


### PR DESCRIPTION
Prettier defaults to:

```json
"printWidth": 80,
"trailingComma": "es5"
```

so we don't need to explicitly specify these rules.

When semi is set to false, [Prettier will insert semi-colons at the start of the line](https://prettier.io/docs/en/rationale.html#semicolons) in scenarios, such as this:

```js
;[1, 2, 3].forEach(num => {
  console.log(num)
})
```

Using semicolons only where required removes some noise, following projects such as Vite and Next.js.