### PR TITLE
Allow user and record params to be passed to <PunditProvider />

### DIFF
--- a/examples/example-data.ts
+++ b/examples/example-data.ts
@@ -2,4 +2,4 @@ import { AuthorisableUser, AuthorisablePost } from './types'
 
 export const author: AuthorisableUser = { id: 1, isAdmin: false }
 export const admin: AuthorisableUser = { id: 2, isAdmin: true }
-export const post: AuthorisablePost = { id: 10, userId: 1 }
+export const post: AuthorisablePost = { id: 10, userId: author.id }

--- a/examples/pundit-provider-example.tsx
+++ b/examples/pundit-provider-example.tsx
@@ -13,17 +13,6 @@ export default function PunditProviderExample(): ReactElement {
   )
   policy.add('destroy', (user: AuthorisableUser) => user.isAdmin)
 
-  // Todo: remove duplication after allowing user and record params to be passed
-  // to <PunditProvider /> to override those passed in via the policy param.
-  const policy2 = new Policy(admin, post)
-  policy2.add('view', () => true)
-  policy2.add(
-    'publish',
-    (user: AuthorisableUser, record: AuthorisablePost) =>
-      user.id === record.userId
-  )
-  policy2.add('destroy', (user: AuthorisableUser) => user.isAdmin)
-
   return (
     <div>
       <h2>Pundit Provider Example</h2>
@@ -41,7 +30,7 @@ export default function PunditProviderExample(): ReactElement {
           </When>
         </ul>
       </PunditProvider>
-      <PunditProvider policy={policy2}>
+      <PunditProvider policy={policy} user={admin}>
         <h3>Admin Abilities:</h3>
         <ul>
           <When can="view">

--- a/examples/when-example.tsx
+++ b/examples/when-example.tsx
@@ -30,13 +30,13 @@ export default function WhenExample(): ReactElement {
       </ul>
       <h3>Admin Abilities:</h3>
       <ul>
-        <When can="view" policy={policy} user={admin} record={post}>
+        <When can="view" policy={policy} user={admin}>
           <li>View</li>
         </When>
-        <When can="publish" policy={policy} user={admin} record={post}>
+        <When can="publish" policy={policy} user={admin}>
           <li>Publish</li>
         </When>
-        <When can="destroy" policy={policy} user={admin} record={post}>
+        <When can="destroy" policy={policy} user={admin}>
           <li>Destroy</li>
         </When>
       </ul>

--- a/src/react/pundit-provider.tsx
+++ b/src/react/pundit-provider.tsx
@@ -3,9 +3,11 @@ import Policy from '../policy'
 
 const PunditContext = React.createContext({ policy: new Policy(null, null) })
 
-interface PunditContextProps {
-  children: JSX.Element | JSX.Element[] | null
+interface PunditProviderProps {
   policy: Policy
+  user?: unknown
+  record?: unknown
+  children: JSX.Element | JSX.Element[] | null
 }
 
 export const usePundit = (): { policy: Policy } => {
@@ -15,10 +17,20 @@ export const usePundit = (): { policy: Policy } => {
 
 export function PunditProvider({
   policy,
+  user,
+  record,
   children,
-}: PunditContextProps): ReactElement {
-  const value = useMemo(() => ({ policy }), [policy])
+}: PunditProviderProps): ReactElement {
+  const value = useMemo(
+    () => ({ policy: policy.copy(user, record) }),
+    [policy, user, record]
+  )
   return (
     <PunditContext.Provider value={value}>{children}</PunditContext.Provider>
   )
+}
+
+PunditProvider.defaultProps = {
+  user: undefined,
+  record: undefined,
 }

--- a/test/react/pundit-provider.test.tsx
+++ b/test/react/pundit-provider.test.tsx
@@ -5,77 +5,209 @@ import { PunditProvider } from '../../src/react/pundit-provider'
 import When from '../../src/react/when'
 
 describe('<PunditProvider />', () => {
-  const user = {}
-  const record = {}
-  const policy = new Policy(user, record)
-  policy.add('view', () => true)
-  policy.add('edit', () => false)
+  describe('policy parameter', () => {
+    const user = {}
+    const record = {}
+    const policy = new Policy(user, record)
+    policy.add('view', () => true)
+    policy.add('edit', () => false)
 
-  it('displays <When /> child when action is permitted', () => {
-    render(
-      <PunditProvider policy={policy}>
-        <When can="view">
-          <button type="button">View</button>
-        </When>
-      </PunditProvider>
-    )
-    expect(screen.queryByText('View')).toBeInTheDocument()
-  })
-
-  it('does not display <When /> child when action is forbidden', () => {
-    render(
-      <PunditProvider policy={policy}>
-        <When can="edit">
-          <button type="button">Edit</button>
-        </When>
-      </PunditProvider>
-    )
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
-  })
-
-  it('authorises multiple <When /> children from a single provider', () => {
-    render(
-      <PunditProvider policy={policy}>
-        <When can="view">
-          <button type="button">View</button>
-        </When>
-        <When can="edit">
-          <button type="button">Edit</button>
-        </When>
-      </PunditProvider>
-    )
-    expect(screen.queryByText('View')).toBeInTheDocument()
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
-  })
-
-  it('authorises nested <When /> child elements', () => {
-    render(
-      <PunditProvider policy={policy}>
-        <When can="view">
-          <>
+    it('displays <When /> child when action is permitted', () => {
+      render(
+        <PunditProvider policy={policy}>
+          <When can="view">
             <button type="button">View</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
+
+    it('does not display <When /> child when action is forbidden', () => {
+      render(
+        <PunditProvider policy={policy}>
+          <When can="edit">
+            <button type="button">Edit</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('authorises multiple <When /> children from a single provider', () => {
+      render(
+        <PunditProvider policy={policy}>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
+          <When can="edit">
+            <button type="button">Edit</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('authorises nested <When /> child elements', () => {
+      render(
+        <PunditProvider policy={policy}>
+          <When can="view">
+            <>
+              <button type="button">View</button>
+              <When can="edit">
+                <button type="button">Edit</button>
+              </When>
+            </>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('does not authorise <When /> children outside of a provider', () => {
+      render(
+        <>
+          <PunditProvider policy={policy}>
+            <div />
+          </PunditProvider>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
+        </>
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
+
+    it('authorises <When /> children from multiple providers', () => {
+      render(
+        <>
+          <PunditProvider policy={policy}>
+            <When can="view">
+              <button type="button">View</button>
+            </When>
+          </PunditProvider>
+          <PunditProvider policy={policy}>
             <When can="edit">
               <button type="button">Edit</button>
             </When>
-          </>
-        </When>
-      </PunditProvider>
-    )
-    expect(screen.queryByText('View')).toBeInTheDocument()
-    expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+          </PunditProvider>
+        </>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('authorises <When /> children from multiple policies', () => {
+      const policy2 = new Policy(user, record)
+      policy2.add('edit', () => false)
+      render(
+        <>
+          <PunditProvider policy={policy}>
+            <When can="view">
+              <button type="button">View</button>
+            </When>
+          </PunditProvider>
+          <PunditProvider policy={policy2}>
+            <When can="edit">
+              <button type="button">Edit</button>
+            </When>
+          </PunditProvider>
+        </>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
   })
 
-  it('does not authorise <When /> children outside of a provider', () => {
-    render(
-      <>
-        <PunditProvider policy={policy}>
-          <div />
+  describe('user parameter', () => {
+    type AuthorisableUser = { isReader: boolean; isEditor: boolean }
+    const user: AuthorisableUser = { isReader: true, isEditor: false }
+    const record = {}
+    const policy = new Policy(null, record)
+    policy.add('view', (userParam: AuthorisableUser) => userParam.isReader)
+    policy.add('edit', (userParam: AuthorisableUser) => userParam.isEditor)
+
+    it('displays <When /> child when action is permitted using "user" param', () => {
+      render(
+        <PunditProvider policy={policy} user={user}>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
         </PunditProvider>
-        <When can="view">
-          <button type="button">View</button>
-        </When>
-      </>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
+
+    it('does not display <When /> child when action is forbidden using "user" param', () => {
+      render(
+        <PunditProvider policy={policy} user={user}>
+          <When can="edit">
+            <button type="button">Edit</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('does not display <When /> child when the "policy" param has a null user and the "user" param is missing', () => {
+      render(
+        <PunditProvider policy={new Policy(null, record)}>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('record parameter', () => {
+    type AuthorisableRecord = { published: boolean }
+    const user = {}
+    const record: AuthorisableRecord = { published: true }
+    const policy = new Policy(user, null)
+    policy.add(
+      'view',
+      (_userParam, recordParam: AuthorisableRecord) => recordParam.published
     )
-    expect(screen.queryByText('View')).not.toBeInTheDocument()
+    policy.add(
+      'edit',
+      (_userParam, recordParam: AuthorisableRecord) => !recordParam.published
+    )
+
+    it('displays <When /> child when action is permitted using "record" param', () => {
+      render(
+        <PunditProvider policy={policy} record={record}>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).toBeInTheDocument()
+    })
+
+    it('does not display <When /> child when action is forbidden using "record" param', () => {
+      render(
+        <PunditProvider policy={policy} record={record}>
+          <When can="edit">
+            <button type="button">Edit</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('Edit')).not.toBeInTheDocument()
+    })
+
+    it('does not display <When /> child when the "policy" param has a null record and the "record" param is missing', () => {
+      render(
+        <PunditProvider policy={new Policy(user, null)}>
+          <When can="view">
+            <button type="button">View</button>
+          </When>
+        </PunditProvider>
+      )
+      expect(screen.queryByText('View')).not.toBeInTheDocument()
+    })
   })
 })

--- a/test/react/when.test.tsx
+++ b/test/react/when.test.tsx
@@ -40,11 +40,12 @@ describe('<When />', () => {
   })
 
   describe('user parameter', () => {
-    const user = {}
+    type AuthorisableUser = { isReader: boolean; isEditor: boolean }
+    const user: AuthorisableUser = { isReader: true, isEditor: false }
     const record = {}
     const policy = new Policy(null, record)
-    policy.add('view', () => true)
-    policy.add('edit', () => false)
+    policy.add('view', (userParam: AuthorisableUser) => userParam.isReader)
+    policy.add('edit', (userParam: AuthorisableUser) => userParam.isEditor)
 
     it('displays <When /> child when action is permitted using "user" param', () => {
       render(
@@ -84,11 +85,18 @@ describe('<When />', () => {
   })
 
   describe('record parameter', () => {
+    type AuthorisableRecord = { published: boolean }
     const user = {}
-    const record = {}
+    const record: AuthorisableRecord = { published: true }
     const policy = new Policy(user, null)
-    policy.add('view', () => true)
-    policy.add('edit', () => false)
+    policy.add(
+      'view',
+      (_userParam, recordParam: AuthorisableRecord) => recordParam.published
+    )
+    policy.add(
+      'edit',
+      (_userParam, recordParam: AuthorisableRecord) => !recordParam.published
+    )
 
     it('displays <When /> child when action is permitted using "record" param', () => {
       render(


### PR DESCRIPTION
* Allows the `user` and `record` params to be passed to `<PunditProvider />`, overriding the policy param (similar to how `<When />` already behaves).
* Adds further test scenarios for `<PunditProvider />`
* Improve test data for `<When />` tests to confirm that params are applied
* Simplify examples
